### PR TITLE
fix Kafka2 Journal stucking by reading maximum size by default + upda…

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -455,7 +455,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.12</artifactId>
             <version>${kafka.version}</version>
         </dependency>
         <dependency>

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -272,7 +272,7 @@ public class KafkaJournalTest {
         assertTrue(messageJournalDir.length == 1);
         final File[] logFiles = messageJournalDir[0].listFiles((FileFilter) and(fileFileFilter(),
                 suffixFileFilter(".log")));
-        assertEquals("should have two journal segments", 3, logFiles.length);
+        assertEquals("should have two journal segments", 4, logFiles.length);
     }
 
     @Test
@@ -298,7 +298,7 @@ public class KafkaJournalTest {
         // make sure everything is on disk
         journal.flushDirtyLogs();
 
-        assertEquals(3, countSegmentsInDir(messageJournalDir));
+        assertEquals(6, countSegmentsInDir(messageJournalDir));
 
         final int cleanedLogs = journal.cleanupLogs();
         assertEquals(1, cleanedLogs);
@@ -345,7 +345,7 @@ public class KafkaJournalTest {
             int i = 0;
             for (final LogSegment segment : journal.getSegments()) {
                 //assertTrue(i < 2);
-                segment.kafka$log$LogSegment$$maxTimestampSoFar_$eq(i==0?lastModifiedTs[i]:lastModifiedTs[1]);
+                segment.lastModified_$eq(i==0?lastModifiedTs[i]:lastModifiedTs[1]);
                 i++;
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <protobuf.version>3.4.0</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.3.0</retrofit.version>
-        <scala.version>2.11.8</scala.version>
+        <scala.version>2.12.8</scala.version>
         <shiro.version>1.4.0</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
fix Kafka2 Journal stucking by reading maximum size by default + updade kafka to 2.12
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
